### PR TITLE
Add auth forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ You can also provide headers for the SSE connection:
 mcpo --port 8000 --api-key "top-secret" --server-type "sse" --headers '{"Authorization": "Bearer token", "X-Custom-Header": "value"}' -- http://127.0.0.1:8001/sse
 ```
 
+When mcpo is used behind **Open WebUI**, the `Authorization` header from each
+incoming request is forwarded to the MCP server when using `sse` or
+`streamable_http` modes. This allows Open WebUI to pass user tokens directly to
+your MCP tools without additional configuration.
+
 To use a Streamable HTTP-compatible MCP server, specify the server type and endpoint:
 
 ```bash

--- a/src/mcpo/main.py
+++ b/src/mcpo/main.py
@@ -67,6 +67,7 @@ async def create_dynamic_endpoints(app: FastAPI, api_dependency=None):
             )
 
         tool_handler = get_tool_handler(
+            app,
             session,
             endpoint_name,
             form_model_fields,

--- a/src/mcpo/utils/main.py
+++ b/src/mcpo/utils/main.py
@@ -105,6 +105,7 @@ async def call_tool_with_forwarded_auth(
         if server_type == "sse":
             async with sse_client(url=app.state.args, headers=headers) as (reader, writer):
                 async with ClientSession(reader, writer) as temp_session:
+                    await temp_session.initialize()
                     return await temp_session.call_tool(endpoint_name, arguments=arguments)
         else:
             url = app.state.args
@@ -116,6 +117,7 @@ async def call_tool_with_forwarded_auth(
                 _,
             ):
                 async with ClientSession(reader, writer) as temp_session:
+                    await temp_session.initialize()
                     return await temp_session.call_tool(endpoint_name, arguments=arguments)
 
     return await session.call_tool(endpoint_name, arguments=arguments)


### PR DESCRIPTION
## Summary
- forward client Authorization header to MCP server
- document token forwarding for Open WebUI

## Testing
- `uv run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68724049454c8320b8ad1c0645c4925f